### PR TITLE
Display all contributing artists in UI and metadata

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -3,6 +3,7 @@ import { API_CONFIG, fetchWithCORS, selectApiTargetForRegion } from './config';
 import type { RegionOption } from '$lib/stores/region';
 import { deriveTrackQuality } from '$lib/utils/audioQuality';
 import { parseTidalUrl, type TidalUrlParseResult } from '$lib/utils/urlParser';
+import { formatArtistsForMetadata } from '$lib/utils';
 import type {
 	Track,
 	Artist,
@@ -1120,11 +1121,10 @@ class LosslessAPI {
 		const entries: Array<[string, string]> = [];
 		const { track } = lookup;
 		const album = track.album;
-		const mainArtist = track.artist?.name ?? track.artists?.[0]?.name;
-		const albumArtist =
-			album?.artist?.name ??
+		const mainArtist = formatArtistsForMetadata(track.artists);
+		const albumArtist = album?.artist?.name ??
 			(album?.artists && album.artists.length > 0 ? album.artists[0]?.name : undefined) ??
-			mainArtist;
+			track.artists?.[0]?.name;
 
 		if (track.title) entries.push(['title', track.title]);
 		if (mainArtist) entries.push(['artist', mainArtist]);

--- a/src/lib/components/AudioPlayer.svelte
+++ b/src/lib/components/AudioPlayer.svelte
@@ -9,6 +9,7 @@
 	import { downloadUiStore, ffmpegBanner, activeTrackDownloads } from '$lib/stores/downloadUi';
 	import { userPreferencesStore } from '$lib/stores/userPreferences';
 	import { sanitizeForFilename, getExtensionForQuality } from '$lib/downloads';
+	import { formatArtists } from '$lib/utils';
 	import type { Track, AudioQuality } from '$lib/types';
 	import { slide } from 'svelte/transition';
 	import { cubicOut } from 'svelte/easing';
@@ -706,7 +707,7 @@
 		const quality = $playerStore.quality;
 		const convertAacToMp3 = $userPreferencesStore.convertAacToMp3;
 		const downloadCoverSeperately = $userPreferencesStore.downloadCoversSeperately;
-		const artistName = track.artist?.name ?? 'Unknown Artist';
+		const artistName = formatArtists(track.artists);
 		const titleName = track.title ?? 'Unknown Track';
 		const ext = getExtensionForQuality(quality, convertAacToMp3);
 		const filename = `${sanitizeForFilename(artistName)} - ${sanitizeForFilename(titleName)}.${ext}`;
@@ -885,7 +886,7 @@
 		try {
 			navigator.mediaSession.metadata = new MediaMetadata({
 				title: track.title,
-				artist: track.artist?.name ?? '',
+				artist: formatArtists(track.artists),
 				album: track.album?.title ?? '',
 				artwork: getMediaSessionArtwork(track)
 			});
@@ -1284,12 +1285,12 @@
 								<h3 class="truncate font-semibold text-white">
 									{$playerStore.currentTrack.title}
 								</h3>
-								<a 
+								<a
 									href={`/artist/${$playerStore.currentTrack.artist.id}`}
 									class="truncate text-sm text-gray-400 hover:text-blue-400 hover:underline inline-block"
 									data-sveltekit-preload-data
 								>
-									{$playerStore.currentTrack.artist.name}
+									{formatArtists($playerStore.currentTrack.artists)}
 								</a>
 								<p class="text-xs text-gray-500">
 									<a 
@@ -1494,13 +1495,13 @@
 													<p class="truncate text-sm font-medium">
 														{queuedTrack.title}
 													</p>
-													<a 
+													<a
 														href={`/artist/${queuedTrack.artist.id}`}
 														onclick={(e) => e.stopPropagation()}
 														class="truncate text-xs text-gray-400 hover:text-blue-400 hover:underline inline-block"
 														data-sveltekit-preload-data
 													>
-														{queuedTrack.artist.name}
+														{formatArtists(queuedTrack.artists)}
 													</a>
 												</div>
 												<button

--- a/src/lib/components/LyricsPopup.svelte
+++ b/src/lib/components/LyricsPopup.svelte
@@ -3,6 +3,7 @@
 	import { onDestroy } from 'svelte';
 	import { currentTime, playerStore } from '$lib/stores/player';
 	import { lyricsStore } from '$lib/stores/lyrics';
+	import { formatArtists } from '$lib/utils';
 	import { Maximize2, Minimize2, RefreshCw, X } from 'lucide-svelte';
 
 	const COMPONENT_MODULE_URL =
@@ -430,7 +431,7 @@
 		}
 
 		const title = track.title;
-		const artist = track.artist?.name ?? '';
+		const artist = formatArtists(track.artists);
 		const album = track.album?.title;
 		const durationMs =
 			typeof track.duration === 'number'

--- a/src/lib/components/SearchInterface.svelte
+++ b/src/lib/components/SearchInterface.svelte
@@ -3,6 +3,7 @@
 	import { losslessAPI, type TrackDownloadProgress } from '$lib/api';
 	import { hasRegionTargets } from '$lib/config';
 	import { downloadAlbum, getExtensionForQuality } from '$lib/downloads';
+	import { formatArtists } from '$lib/utils';
 	import { playerStore } from '$lib/stores/player';
 	import { downloadUiStore } from '$lib/stores/downloadUi';
 	import { downloadPreferencesStore } from '$lib/stores/downloadPreferences';
@@ -214,9 +215,9 @@
 
 		const quality = $playerStore.quality;
 		const extension = getExtensionForQuality(quality, convertAacToMp3Preference);
-		const filename = `${track.artist.name} - ${track.title}.${extension}`;
+		const filename = `${formatArtists(track.artists)} - ${track.title}.${extension}`;
 		const { taskId, controller } = downloadUiStore.beginTrackDownload(track, filename, {
-			subtitle: track.album?.title ?? track.artist?.name
+			subtitle: track.album?.title ?? formatArtists(track.artists)
 		});
 		const taskMap = new Map(downloadTaskIds);
 		taskMap.set(track.id, taskId);
@@ -676,9 +677,9 @@
 			try {
 				const quality = $playerStore.quality;
 				const extension = getExtensionForQuality(quality, convertAacToMp3Preference);
-				const filename = `${track.artist.name} - ${track.title}.${extension}`;
+				const filename = `${formatArtists(track.artists)} - ${track.title}.${extension}`;
 				const { taskId, controller } = downloadUiStore.beginTrackDownload(track, filename, {
-					subtitle: track.album?.title ?? track.artist?.name
+					subtitle: track.album?.title ?? formatArtists(track.artists)
 				});
 				
 				await losslessAPI.downloadTrack(track.id, quality, filename, {
@@ -1015,13 +1016,13 @@
 									>
 								{/if}
 							</h3>
-							<a 
+							<a
 								href={`/artist/${track.artist.id}`}
 								onclick={(e) => e.stopPropagation()}
 								class="truncate text-sm text-gray-400 hover:text-blue-400 hover:underline inline-block"
 								data-sveltekit-preload-data
 							>
-								{track.artist.name}
+								{formatArtists(track.artists)}
 							</a>
 							<p class="text-xs text-gray-500">
 								<a 

--- a/src/lib/components/TopTracksGrid.svelte
+++ b/src/lib/components/TopTracksGrid.svelte
@@ -5,6 +5,7 @@
 	import { playerStore } from '$lib/stores/player';
 	import { downloadUiStore } from '$lib/stores/downloadUi';
 	import { userPreferencesStore } from '$lib/stores/userPreferences';
+	import { formatArtists } from '$lib/utils';
 	import { Play, Pause, Download, ListPlus, Plus, Clock, X } from 'lucide-svelte';
 
 	interface Props {
@@ -105,7 +106,7 @@
 
 		const quality = $playerStore.quality;
 		const extension = getExtensionForQuality(quality, convertAacToMp3Preference);
-		const filename = `${track.artist.name} - ${track.title}.${extension}`;
+		const filename = `${formatArtists(track.artists)} - ${track.title}.${extension}`;
 		const { taskId, controller } = downloadUiStore.beginTrackDownload(track, filename, {
 			subtitle: track.album?.title ?? track.artist?.name
 		});
@@ -218,7 +219,7 @@
 							{/if}
 						</h3>
 						<div class="mt-1 space-y-1 text-sm text-gray-400">
-							<p class="truncate">{track.artist.name}</p>
+							<p class="truncate">{formatArtists(track.artists)}</p>
 							{#if track.album}
 								<p class="truncate text-xs text-gray-500">{track.album.title}</p>
 							{/if}

--- a/src/lib/components/TrackList.svelte
+++ b/src/lib/components/TrackList.svelte
@@ -5,6 +5,7 @@
 	import { playerStore } from '$lib/stores/player';
 	import { downloadUiStore } from '$lib/stores/downloadUi';
 	import { userPreferencesStore } from '$lib/stores/userPreferences';
+	import { formatArtists } from '$lib/utils';
 	import { Play, Pause, Download, Clock, Plus, ListPlus, X } from 'lucide-svelte';
 
 	interface Props {
@@ -96,7 +97,7 @@
 
 		const quality = $playerStore.quality;
 		const extension = getExtensionForQuality(quality, convertAacToMp3Preference);
-		const filename = `${track.artist.name} - ${track.title}.${extension}`;
+		const filename = `${formatArtists(track.artists)} - ${track.title}.${extension}`;
 		const { taskId, controller } = downloadUiStore.beginTrackDownload(track, filename, {
 			subtitle: showAlbum ? (track.album?.title ?? track.artist?.name) : track.artist?.name
 		});
@@ -231,7 +232,7 @@
 						</h3>
 						<div class="flex items-center gap-2 text-sm text-gray-400">
 							{#if showArtist}
-								<span class="truncate">{track.artist.name}</span>
+								<span class="truncate">{formatArtists(track.artists)}</span>
 							{/if}
 							{#if showAlbum && showArtist}
 								<span>•</span>

--- a/src/lib/downloads.ts
+++ b/src/lib/downloads.ts
@@ -1,6 +1,7 @@
 import { losslessAPI } from '$lib/api';
 import type { Album, Track, AudioQuality } from '$lib/types';
 import type { DownloadMode } from '$lib/stores/downloadPreferences';
+import { formatArtists } from '$lib/utils';
 import JSZip from 'jszip';
 
 function detectImageFormat(data: Uint8Array): { extension: string; mimeType: string } | null {
@@ -74,7 +75,7 @@ export function buildTrackFilename(
 	}
 	
 	const parts = [
-		sanitizeForFilename(artistName ?? track.artist?.name ?? 'Unknown Artist'),
+		sanitizeForFilename(artistName ?? formatArtists(track.artists)),
 		sanitizeForFilename(album.title ?? 'Unknown Album'),
 		`${trackPart} ${sanitizeForFilename(track.title)}`
 	];
@@ -103,7 +104,7 @@ export async function buildTrackLinksCsv(tracks: Track[], quality: AudioQuality)
 		rows.push([
 			`${index + 1}`,
 			track.title ?? '',
-			track.artist?.name ?? '',
+			formatArtists(track.artists),
 			track.album?.title ?? '',
 			losslessAPI.formatDuration(track.duration ?? 0),
 			streamUrl

--- a/src/lib/stores/downloadUi.ts
+++ b/src/lib/stores/downloadUi.ts
@@ -1,5 +1,6 @@
 import { derived, get, writable } from 'svelte/store';
 import type { Track } from '$lib/types';
+import { formatArtists } from '$lib/utils';
 
 export type FfmpegPhase = 'idle' | 'countdown' | 'loading' | 'ready' | 'error';
 
@@ -164,7 +165,7 @@ export const downloadUiStore = {
 			id,
 			trackId: track.id,
 			title: track.title,
-			subtitle: options?.subtitle ?? track.artist?.name ?? 'Unknown artist',
+			subtitle: options?.subtitle ?? formatArtists(track.artists),
 			filename,
 			status: 'running',
 			receivedBytes: 0,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,45 @@
+import type { Artist } from './types';
+
+/**
+ * Formats an array of artists into a readable string for UI display.
+ * For single artist: "Artist Name"
+ * For multiple artists: "Artist1, Artist2 & Artist3"
+ *
+ * @param artists - Array of artists
+ * @returns Formatted artist string
+ */
+export function formatArtists(artists: Artist[] | undefined): string {
+	if (!artists || artists.length === 0) {
+		return 'Unknown Artist';
+	}
+
+	if (artists.length === 1) {
+		return artists[0].name;
+	}
+
+	if (artists.length === 2) {
+		return `${artists[0].name} & ${artists[1].name}`;
+	}
+
+	// For 3 or more artists: "Artist1, Artist2 & Artist3"
+	const allButLast = artists.slice(0, -1).map(a => a.name).join(', ');
+	const last = artists[artists.length - 1].name;
+	return `${allButLast} & ${last}`;
+}
+
+/**
+ * Formats an array of artists for metadata tags (ID3, etc.).
+ * Uses semicolons as the standard delimiter.
+ * For single artist: "Artist Name"
+ * For multiple artists: "Artist1; Artist2; Artist3"
+ *
+ * @param artists - Array of artists
+ * @returns Formatted artist string for metadata
+ */
+export function formatArtistsForMetadata(artists: Artist[] | undefined): string {
+	if (!artists || artists.length === 0) {
+		return 'Unknown Artist';
+	}
+
+	return artists.map(a => a.name).join('; ');
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -14,6 +14,7 @@
 	import { effectivePerformanceLevel } from '$lib/stores/performance';
 	import { losslessAPI, type TrackDownloadProgress } from '$lib/api';
 	import { sanitizeForFilename, getExtensionForQuality, buildTrackLinksCsv } from '$lib/downloads';
+	import { formatArtists } from '$lib/utils';
 	import { navigating } from '$app/stores';
 	import JSZip from 'jszip';
 	import {
@@ -155,7 +156,7 @@
 		const isPlaying = $playerStore.isPlaying;
 		
 		if (track) {
-			const artist = track.artist?.name ?? 'Unknown Artist';
+			const artist = formatArtists(track.artists);
 			const title = track.title ?? 'Unknown Track';
 			const prefix = isPlaying ? '▶' : '⏸';
 			document.title = `${prefix} ${title} • ${artist} | BiniTidal`;
@@ -177,7 +178,7 @@
 	function buildQueueFilename(track: Track, index: number, quality: AudioQuality): string {
 		const ext = getExtensionForQuality(quality, convertAacToMp3);
 		const order = `${index + 1}`.padStart(2, '0');
-		const artistName = sanitizeForFilename(track.artist?.name ?? 'Unknown Artist');
+		const artistName = sanitizeForFilename(formatArtists(track.artists));
 		const titleName = sanitizeForFilename(track.title ?? `Track ${order}`);
 		return `${order} - ${artistName} - ${titleName}.${ext}`;
 	}
@@ -266,7 +267,7 @@
 			for (const [index, track] of tracks.entries()) {
 				const filename = buildQueueFilename(track, index, quality);
 				const { taskId, controller } = downloadUiStore.beginTrackDownload(track, filename, {
-					subtitle: track.album?.title ?? track.artist?.name
+					subtitle: track.album?.title ?? formatArtists(track.artists)
 				});
 				downloadUiStore.skipFfmpegCountdown();
 
@@ -304,7 +305,7 @@
 					}
 					console.error('Failed to download track from queue:', error);
 					downloadUiStore.errorTrackDownload(taskId, error);
-					const label = `${track.artist?.name ?? 'Unknown Artist'} - ${track.title ?? 'Unknown Track'}`;
+					const label = `${formatArtists(track.artists)} - ${track.title ?? 'Unknown Track'}`;
 					const message =
 						error instanceof Error && error.message
 							? error.message


### PR DESCRIPTION
Tracks now properly show all artists (featured, collaborating) instead of just the primary artist. UI and metadata are properly updated to reflect these changes.