### PR TITLE
Ensure single track downloads use full album-style filename metadata

### DIFF
--- a/src/lib/components/TopTracksGrid.svelte
+++ b/src/lib/components/TopTracksGrid.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { Track } from '$lib/types';
 	import { losslessAPI, type TrackDownloadProgress } from '$lib/api';
-	import { getExtensionForQuality } from '$lib/downloads';
+	import { getExtensionForQuality, buildTrackFilename } from '$lib/downloads';
 	import { playerStore } from '$lib/stores/player';
 	import { downloadUiStore } from '$lib/stores/downloadUi';
 	import { userPreferencesStore } from '$lib/stores/userPreferences';
@@ -33,7 +33,9 @@
 	let downloadTaskIds = $state(new Map<number, string>());
 	let cancelledIds = $state(new Set<number>());
 	const convertAacToMp3Preference = $derived($userPreferencesStore.convertAacToMp3);
-	const downloadCoverSeperatelyPreference = $derived($userPreferencesStore.downloadCoversSeperately);
+	const downloadCoverSeperatelyPreference = $derived(
+		$userPreferencesStore.downloadCoversSeperately
+	);
 
 	const IGNORED_TAGS = new Set(['HI_RES_LOSSLESS']);
 
@@ -105,8 +107,13 @@
 		downloadingIds = next;
 
 		const quality = $playerStore.quality;
-		const extension = getExtensionForQuality(quality, convertAacToMp3Preference);
-		const filename = `${formatArtists(track.artists)} - ${track.title}.${extension}`;
+		const filename = buildTrackFilename(
+			track.album,
+			track,
+			quality,
+			formatArtists(track.artists),
+			convertAacToMp3Preference
+		);
 		const { taskId, controller } = downloadUiStore.beginTrackDownload(track, filename, {
 			subtitle: track.album?.title ?? track.artist?.name
 		});

--- a/src/lib/components/TrackList.svelte
+++ b/src/lib/components/TrackList.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { Track } from '$lib/types';
 	import { losslessAPI, type TrackDownloadProgress } from '$lib/api';
-	import { getExtensionForQuality } from '$lib/downloads';
+	import { getExtensionForQuality, buildTrackFilename } from '$lib/downloads';
 	import { playerStore } from '$lib/stores/player';
 	import { downloadUiStore } from '$lib/stores/downloadUi';
 	import { userPreferencesStore } from '$lib/stores/userPreferences';
@@ -96,8 +96,13 @@
 		downloadingIds = next;
 
 		const quality = $playerStore.quality;
-		const extension = getExtensionForQuality(quality, convertAacToMp3Preference);
-		const filename = `${formatArtists(track.artists)} - ${track.title}.${extension}`;
+		const filename = buildTrackFilename(
+			track.album,
+			track,
+			quality,
+			formatArtists(track.artists),
+			convertAacToMp3Preference
+		);
 		const { taskId, controller } = downloadUiStore.beginTrackDownload(track, filename, {
 			subtitle: showAlbum ? (track.album?.title ?? track.artist?.name) : track.artist?.name
 		});


### PR DESCRIPTION
This merge request addresses an inconsistency in filename generation between single track and album downloads.  

- **Current behavior:**  
  - Single track download → `{artist} - {title}.{extension}`  
  - Album download → `{artist} - {album} - {volume}-{track number} {title}.{extension}`  

- **Problem:**  
  Single track downloads lack important metadata (album name, track number, volume) that are included when downloading an entire album. This results in inconsistent filenames and makes file organization less clear.  

- **Solution:**  
  Centralized the filename generation logic so that single track downloads now follow the same schema as album downloads:  
  `{artist} - {album} - {volume}-{track number} {title}.{extension}`  

- **Impact:**  
  - Uniform naming convention across all downloads.  
  - Improved clarity and consistency in local music libraries.  
  - No breaking changes for existing album downloads.  
