### PR TITLE
fix: overflowing text in player and search results

### DIFF
--- a/src/lib/components/AudioPlayer.svelte
+++ b/src/lib/components/AudioPlayer.svelte
@@ -1508,24 +1508,24 @@
 									{/if}
 								{/if}
 								<div class="min-w-0 flex-1">
-									<h3 class="truncate font-semibold text-white">
+									<h3 class="truncate font-semibold text-white w-full">
 										{$playerStore.currentTrack.title}{!isSonglinkTrack($playerStore.currentTrack) && asTrack($playerStore.currentTrack).version ? ` (${asTrack($playerStore.currentTrack).version})` : ''}
 									</h3>
 									{#if isSonglinkTrack($playerStore.currentTrack)}
 										<!-- Display for SonglinkTrack -->
-										<p class="truncate text-sm text-gray-400">
+										<p class="truncate text-sm text-gray-400 w-full">
 											{$playerStore.currentTrack.artistName}
 										</p>
 									{:else}
 										<!-- Display for regular Track -->
 										<a
 											href={`/artist/${asTrack($playerStore.currentTrack).artist.id}`}
-											class="truncate text-sm text-gray-400 hover:text-blue-400 hover:underline inline-block"
+											class="truncate text-sm text-gray-400 hover:text-blue-400 hover:underline inline-block w-full"
 											data-sveltekit-preload-data
 										>
 											{formatArtists(asTrack($playerStore.currentTrack).artists)}
 										</a>
-										<p class="text-xs text-gray-500">
+										<p class="truncate text-xs text-gray-500 w-full">
 											<a
 												href={`/album/${asTrack($playerStore.currentTrack).album.id}`}
 												class="hover:text-blue-400 hover:underline"

--- a/src/lib/components/SearchInterface.svelte
+++ b/src/lib/components/SearchInterface.svelte
@@ -1169,10 +1169,10 @@
 								class="h-12 w-12 flex-shrink-0 rounded object-cover"
 							/>
 							<div class="min-w-0 flex-1">
-								<h3 class="truncate font-semibold text-white group-hover:text-blue-400">
+								<h3 class="truncate font-semibold text-white group-hover:text-blue-400 w-full">
 									{track.title}
 								</h3>
-								<p class="truncate text-sm text-gray-400">
+								<p class="truncate text-sm text-gray-400 w-full">
 									{track.artistName}
 								</p>
 								<p class="text-xs text-gray-500">
@@ -1266,7 +1266,7 @@
 								/>
 							{/if}
 							<div class="min-w-0 flex-1">
-								<h3 class="truncate font-semibold text-white group-hover:text-blue-400">
+								<h3 class="truncate font-semibold text-white group-hover:text-blue-400 w-full">
 									{track.title}{asTrack(track).version ? ` (${asTrack(track).version})` : ''}
 									{#if asTrack(track).explicit}
 										<svg
@@ -1286,7 +1286,7 @@
 								</h3>
 								<a
 									href={`/artist/${asTrack(track).artist.id}`}
-									class="inline-block truncate text-sm text-gray-400 hover:text-blue-400 hover:underline"
+									class="inline-block truncate text-sm text-gray-400 hover:text-blue-400 hover:underline w-full"
 									data-sveltekit-preload-data
 								>
 									{formatArtists(asTrack(track).artists)}
@@ -1462,7 +1462,7 @@
 									</div>
 								{/if}
 							</div>
-							<h3 class="truncate font-semibold text-white group-hover:text-blue-400">
+							<h3 class="truncate font-semibold text-white group-hover:text-blue-400 w-full">
 								{album.title}
 								{#if album.explicit}
 									<svg
@@ -1481,7 +1481,7 @@
 								{/if}
 							</h3>
 							{#if album.artist}
-								<p class="truncate text-sm text-gray-400">{album.artist.name}</p>
+								<p class="truncate text-sm text-gray-400 w-full">{album.artist.name}</p>
 							{/if}
 							{#if album.releaseDate}
 								<p class="text-xs text-gray-500">{album.releaseDate.split('-')[0]}</p>
@@ -1524,7 +1524,7 @@
 								</div>
 							{/if}
 						</div>
-						<h3 class="truncate font-semibold text-white group-hover:text-blue-400">
+						<h3 class="truncate font-semibold text-white group-hover:text-blue-400 w-full">
 							{artist.name}
 						</h3>
 						<p class="text-xs text-gray-500">Artist</p>
@@ -1548,10 +1548,10 @@
 								/>
 							{/if}
 						</div>
-						<h3 class="truncate font-semibold text-white group-hover:text-blue-400">
+						<h3 class="truncate font-semibold text-white group-hover:text-blue-400 w-full">
 							{playlist.title}
 						</h3>
-						<p class="truncate text-sm text-gray-400">{playlist.creator.name}</p>
+						<p class="truncate text-sm text-gray-400 w-full">{playlist.creator.name}</p>
 						<p class="text-xs text-gray-500">{playlist.numberOfTracks} tracks</p>
 					</a>
 			{/each}


### PR DESCRIPTION
Because we didn't set any max width, the tailwind `truncate` property didn't actually do anything (at least on Firefox).

Screenshot before:
<img width="1230" height="162" alt="Screenshot from 2026-01-30 14-23-22" src="https://github.com/user-attachments/assets/dc1d5ae6-bb12-4745-a71c-b36d88153956" />

Screenshot after:
<img width="1230" height="162" alt="Screenshot from 2026-01-30 14-24-30" src="https://github.com/user-attachments/assets/8c1e30b7-1202-43ba-a1af-755b4ca7c8a8" />
