### PR TITLE
feat: support for autoplay when playing from search

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -16,7 +16,8 @@ import type {
 	Lyrics,
 	TrackInfo,
 	TrackLookup,
-	ArtistDetails
+	ArtistDetails,
+	TrackRecommendationsResponse
 } from './types';
 
 const API_BASE = API_CONFIG.baseUrl;
@@ -1022,6 +1023,19 @@ class LosslessAPI {
 		}
 
 		throw lastError ?? new Error('Failed to get track');
+	}
+
+	async getRecommendations(trackId: number): Promise<Track[]> {
+		const response = await this.fetch(`${this.baseUrl}/recommendations/?id=${trackId}`);
+		this.ensureNotRateLimited(response);
+		if (!response.ok) {
+			throw new Error('Failed to fetch track recommendations');
+		}
+		const payload: TrackRecommendationsResponse = await response.json();
+		if (!payload.data.items) {
+			throw new Error('No recommendations found');
+		}
+		return payload.data.items.map(item => item.track);
 	}
 
 	async getDashManifest(

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -156,6 +156,19 @@ export interface TrackLookup {
 	originalTrackUrl?: string;
 }
 
+export interface TrackRecommendationsResponse {
+	version: string,
+	data: {
+		limit: number;
+		offset: number;
+		totalNumberOfItems: number,
+		items: {
+			track: Track;
+			sources: string[]
+		}[]
+	}
+}
+
 /**
  * Songlink API response types (copied to avoid circular dependency)
  */

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
 	import SearchInterface from '$lib/components/SearchInterface.svelte';
-	import type { Track, PlayableTrack } from '$lib/types';
+	import { type Track, type PlayableTrack, isSonglinkTrack } from '$lib/types';
 	import { playerStore } from '$lib/stores/player';
 	import { onMount } from 'svelte';
 	import { APP_VERSION } from '$lib/version';
+	import { losslessAPI } from '$lib/api.js';
 
 	let { data } = $props();
 
@@ -15,9 +16,18 @@
 		}
 	});
 
+	async function fillQueueWithRecommendations(track: PlayableTrack) {
+		if (isSonglinkTrack(track)) return;
+
+		const recommendations = await losslessAPI.getRecommendations(track.id);
+		playerStore.setQueue([track, ...recommendations], 0);
+	}
+
 	function handleTrackSelect(track: PlayableTrack) {
 		playerStore.setQueue([track], 0);
 		playerStore.play();
+
+		fillQueueWithRecommendations(track);
 	}
 </script>
 


### PR DESCRIPTION
With this PR, related songs are automatically loaded into the queue when selecting a track from search results. This is somewhat similar to a "radio mode" from other apps, with the current limitation that once the queue is finished, it doesn't fill up more songs automatically (yet).

requires https://github.com/binimum/hifi-api/pull/9
addresses (but not fully solves) https://github.com/binimum/tidal-ui/issues/83