### PR TITLE
fix: hardcoded share URLs

### DIFF
--- a/src/lib/components/SearchInterface.svelte
+++ b/src/lib/components/SearchInterface.svelte
@@ -45,9 +45,10 @@
 	} from 'lucide-svelte';
 
 	import { searchStore, type SearchTab } from '$lib/stores/searchStore.svelte';
+	import { page } from '$app/stores';
 
 	function getLongLink(type: 'track' | 'album' | 'artist' | 'playlist', id: string | number) {
-		return `https://music.binimum.org/${type}/${id}`;
+		return `${$page.url.protocol}://${$page.url.host}/${type}/${id}`;
 	}
 
 	function getShortLink(type: 'track' | 'album' | 'artist' | 'playlist', id: string | number) {

--- a/src/lib/components/ShareButton.svelte
+++ b/src/lib/components/ShareButton.svelte
@@ -2,6 +2,7 @@
 	import { Share2, Link, Copy, Check, Code } from 'lucide-svelte';
 	import { fade, scale } from 'svelte/transition';
 	import { onMount } from 'svelte';
+	import { page } from '$app/stores';
 
 	interface Props {
 		type: 'track' | 'album' | 'artist' | 'playlist';
@@ -27,7 +28,11 @@
 	let buttonRef: HTMLButtonElement | null = null;
 
 	function getLongLink() {
-		return `https://music.binimum.org/${type}/${id}`;
+		return `${$page.url.protocol}://${$page.url.host}/${type}/${id}`;
+	}
+
+	function getEmbedUrl() {
+		return `${$page.url.protocol}://${$page.url.host}/embed/${type}/${id}`;
 	}
 
 	function getShortLink() {
@@ -41,8 +46,8 @@
 	}
 
 	function getEmbedCode() {
-        if (type === "track") return `<iframe src="https://music.binimum.org/embed/${type}/${id}" width="100%" height="150" style="border:none; overflow:hidden; border-radius: 0.5em;" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"></iframe>`;
-		return `<iframe src="https://music.binimum.org/embed/${type}/${id}" width="100%" height="450" style="border:none; overflow:hidden; border-radius: 0.5em;" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"></iframe>`;
+        if (type === "track") return `<iframe src="${getEmbedUrl()}" width="100%" height="150" style="border:none; overflow:hidden; border-radius: 0.5em;" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"></iframe>`;
+		return `<iframe src="${getEmbedUrl()}" width="100%" height="450" style="border:none; overflow:hidden; border-radius: 0.5em;" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"></iframe>`;
 	}
 
 	async function copyToClipboard(text: string) {


### PR DESCRIPTION
If self-hosting BiniLossless, the share URLs would still point to `music.binimum.org` instead of the self-hosted version without this fix.